### PR TITLE
Put the settings in a settings block

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -4,6 +4,7 @@ description: A template for testing Flourish
 author: Flourish team
 sdk_version: 3
 settings:
+  - Sample settings block
   - property: boolean
     name: Boolean
     type: boolean


### PR DESCRIPTION
The reason for this is that the generic `createVisualisation` code in the Cypress QA tests assumes that all settings are contained in a settings block (and to be fair, this is the typical case).